### PR TITLE
Fix `value` field of `CommandInteractionDataOption`

### DIFF
--- a/src/Discord/interaction.ts
+++ b/src/Discord/interaction.ts
@@ -54,9 +54,11 @@ export type CommandInteractionData = {
 export type CommandInteractionDataOption = {
   name: string;
   type: CommandOptionType;
-  value?: CommandOptionType;
+  value?: OptionType;
   options?: CommandInteractionDataOption[];
 };
+
+export type OptionType = string | number | boolean | User | Channel | Role;
 
 export enum CommandOptionType {
   SUB_COMMAND = 1,


### PR DESCRIPTION
`CommandInteractionDataOption` has two fields that we'll look at.  First
is `type`, which has the type of `CommandOptionType`, an `enum` that
stores the possible types of `CommandOptions`. `CommandOptions` are
arguments to the bot's slash commands.

Referencing the documentation here:

https://discord.com/developers/docs/interactions/slash-commands
#interaction-response

According to the documentation, the second field `value?` actually has
the type of `OptionType`. In the code, the type of `value?` is set to
the `CommandOptionType` `enum`. Rather, it should be a type _found_ in
the `enum`, since the values of the `enum` are integers.

This commit fixes that problem, allowing `value?` to have a value of the
`CommandOption` types by exporting a new type `OptionType`. However, it
does not offer 100% coverage of the possible values. I did not include
`Mentionable` because I did not find an existing `Mentionable` type. It
also does not include `SUB_COMMAND` or `SUB_COMMAND_GROUP`, because I
have no idea what those are.

Signed-off-by: Lucas Sta Maria <lucas.stamaria@gmail.com>