### PR TITLE
Add list-joined command to list only joined courses

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -30,7 +30,8 @@ This is a list of commands currently implemented in Hoosky Bot.
 | ---------------------------- | ---------------------------------------------------------------------------------------- |
 | `/course create [name] [id]` | Creates a new course and associated server role. Requires the `MANAGE_ROLES` permission. |
 | `/course delete [@role]`     | Removes a course and associated server role. Requires the `MANAGE_ROLES` permission.     |
-| `/course list`               | Silently lists all available courses.                                                    |
+| `/course list-all`               | Silently lists all available courses.         
+| `/course list-joined [@user?]`               | Silently lists all joined courses for the specified user. If no user is specified, defaults to the user who ran the command.                                             |
 | `/course join [@role]`       | Joins a course and assigns the appropriate course role to the user.                      |
 | `/course leave [@role]`      | Leaves a course and removes the course role from the user.                               |
 | `/course roster [@role]`     | Silently lists all members currently in the course.                                      |

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -3,6 +3,7 @@
 This is a list of commands currently implemented in Hoosky Bot.
 
 > Note: `[]` indicates a variable argument.
+> Note: `[?]` indicates an optional argument.
 
 ## `/ping`
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -26,12 +26,12 @@ This is a list of commands currently implemented in Hoosky Bot.
 
 ## `/course`
 
-| Command                      | Description                                                                              |
-| ---------------------------- | ---------------------------------------------------------------------------------------- |
-| `/course create [name] [id]` | Creates a new course and associated server role. Requires the `MANAGE_ROLES` permission. |
-| `/course delete [@role]`     | Removes a course and associated server role. Requires the `MANAGE_ROLES` permission.     |
-| `/course list-all`               | Silently lists all available courses.         
-| `/course list-joined [@user?]`               | Silently lists all joined courses for the specified user. If no user is specified, defaults to the user who ran the command.                                             |
-| `/course join [@role]`       | Joins a course and assigns the appropriate course role to the user.                      |
-| `/course leave [@role]`      | Leaves a course and removes the course role from the user.                               |
-| `/course roster [@role]`     | Silently lists all members currently in the course.                                      |
+| Command                        | Description                                                                                                                  |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `/course create [name] [id]`   | Creates a new course and associated server role. Requires the `MANAGE_ROLES` permission.                                     |
+| `/course delete [@role]`       | Removes a course and associated server role. Requires the `MANAGE_ROLES` permission.                                         |
+| `/course list-all`             | Silently lists all available courses.                                                                                        |
+| `/course list-joined [@user?]` | Silently lists all joined courses for the specified user. If no user is specified, defaults to the user who ran the command. |
+| `/course join [@role]`         | Joins a course and assigns the appropriate course role to the user.                                                          |
+| `/course leave [@role]`        | Leaves a course and removes the course role from the user.                                                                   |
+| `/course roster [@role]`       | Silently lists all members currently in the course.                                                                          |

--- a/src/commands/course/subcommands/_listAll.ts
+++ b/src/commands/course/subcommands/_listAll.ts
@@ -9,9 +9,9 @@ type SubjectGroup = {
   list: string;
 };
 
-export const list = new SubCommand({
-  name: 'list',
-  displayName: 'List Courses',
+export const listAll = new SubCommand({
+  name: 'list-all',
+  displayName: 'List All Courses',
   description: 'Lists all available courses',
   handler: async ctx => {
     const guildId = ctx.mustGetGuildId();
@@ -36,6 +36,7 @@ export const list = new SubCommand({
       }
 
       // Write the course to the subject group.
+      
       curGroup.list += semiBoldCourse(c) + '\n';
       c = await courses.next();
     }

--- a/src/commands/course/subcommands/_listAll.ts
+++ b/src/commands/course/subcommands/_listAll.ts
@@ -36,7 +36,7 @@ export const listAll = new SubCommand({
       }
 
       // Write the course to the subject group.
-      
+
       curGroup.list += semiBoldCourse(c) + '\n';
       c = await courses.next();
     }

--- a/src/commands/course/subcommands/_listJoined.ts
+++ b/src/commands/course/subcommands/_listJoined.ts
@@ -1,0 +1,88 @@
+import * as Discord from '../../../Discord';
+import SubCommand from '../../../SubCommand';
+import CommandOption from '../../../CommandOption';
+import { semiBoldCourse, scanCourses, getCourseMembers } from '../_common';
+import { fancyCenter } from '../../../format';
+
+type SubjectGroup = {
+  subject: string;
+  heading: string;
+  list: string;
+};
+
+export const listJoined = new SubCommand({
+  name: 'list-joined',
+  displayName: 'List Courses',
+  description: 'Lists all available courses',
+  options: [
+    new CommandOption({
+      name: 'user',
+      description: 'Optional user, defaults to self if left empty',
+      required: false,
+      type: Discord.CommandOptionType.USER,
+    }),
+  ],
+  handler: async ctx => {
+    const guildId = ctx.mustGetGuildId();
+    const courses = (await scanCourses(ctx, guildId)).sort({ _id: 1 });
+    const chosenUserId = ctx.getArgument<string>('user') as string;
+    let userId;
+
+    if (chosenUserId) {
+      userId = chosenUserId;
+    }
+    else {
+      userId = ctx.interaction.member?.user?.id;
+      if (!userId) {
+        return ctx.respondWithError('Unable to identify you');
+      }
+    }
+
+    const guildMember = await ctx.api.getGuildMember(guildId, userId);
+    const member = await ctx.api.getUser(userId);
+
+    // Nickname if exists, otherwise username
+    const username = guildMember.nick || member.username;
+    
+    // Hold an array of subject groups to output.
+    const subGroups: SubjectGroup[] = [];
+    // Record the current subject being written to.
+    let curGroup: SubjectGroup | null = null;
+
+    // Iterate over every course.
+    let c = await courses.next();
+    while (c !== null) {
+
+
+      const members = c.members;
+      // If the current member is in the course
+      if (members.includes(userId)) {
+        // If the course's subject is different, then create a new subject group.
+        if (!curGroup || c.subject !== curGroup.subject) {
+          curGroup = {
+            subject: c.subject,
+            heading: fancyCenter(c.subject, 50),
+            list: '',
+          };
+          subGroups.push(curGroup);
+        }
+
+        // Write the course to the subject group.
+        curGroup.list += semiBoldCourse(c) + '\n';
+      }
+      c = await courses.next();
+    }
+
+    // Map subject groups to Discord embed fields.
+    const fields: Discord.EmbedField[] = subGroups.map(sub => ({
+      name: sub.heading, // The subject name.
+      value: sub.list, // The course list.
+    }));
+
+    await ctx.respondSilentlyWithEmbed({
+      type: Discord.EmbedType.RICH,
+      title: `Course List for ${username}`,
+      fields,
+    });
+  },
+});

--- a/src/commands/course/subcommands/_listJoined.ts
+++ b/src/commands/course/subcommands/_listJoined.ts
@@ -1,7 +1,7 @@
 import * as Discord from '../../../Discord';
 import SubCommand from '../../../SubCommand';
 import CommandOption from '../../../CommandOption';
-import { semiBoldCourse, scanCourses, getCourseMembers } from '../_common';
+import { semiBoldCourse, scanCourses } from '../_common';
 import { fancyCenter } from '../../../format';
 
 type SubjectGroup = {
@@ -30,8 +30,7 @@ export const listJoined = new SubCommand({
 
     if (chosenUserId) {
       userId = chosenUserId;
-    }
-    else {
+    } else {
       userId = ctx.interaction.member?.user?.id;
       if (!userId) {
         return ctx.respondWithError('Unable to identify you');
@@ -43,7 +42,7 @@ export const listJoined = new SubCommand({
 
     // Nickname if exists, otherwise username
     const username = guildMember.nick || member.username;
-    
+
     // Hold an array of subject groups to output.
     const subGroups: SubjectGroup[] = [];
     // Record the current subject being written to.
@@ -52,8 +51,6 @@ export const listJoined = new SubCommand({
     // Iterate over every course.
     let c = await courses.next();
     while (c !== null) {
-
-
       const members = c.members;
       // If the current member is in the course
       if (members.includes(userId)) {

--- a/src/commands/course/subcommands/index.ts
+++ b/src/commands/course/subcommands/index.ts
@@ -6,6 +6,14 @@ import { listAll } from './_listAll';
 import { listJoined } from './_listJoined';
 import { roster } from './_roster';
 
-export const subcommands = [create, del, join, leave, listAll, listJoined, roster];
+export const subcommands = [
+  create,
+  del,
+  join,
+  leave,
+  listAll,
+  listJoined,
+  roster,
+];
 
 export default subcommands;

--- a/src/commands/course/subcommands/index.ts
+++ b/src/commands/course/subcommands/index.ts
@@ -2,9 +2,10 @@ import { create } from './_create';
 import { del } from './_delete';
 import { join } from './_join';
 import { leave } from './_leave';
-import { list } from './_list';
+import { listAll } from './_listAll';
+import { listJoined } from './_listJoined';
 import { roster } from './_roster';
 
-export const subcommands = [create, del, join, leave, list, roster];
+export const subcommands = [create, del, join, leave, listAll, listJoined, roster];
 
 export default subcommands;


### PR DESCRIPTION
This adds the `course list-joined [user?]` command and renames the current list command to `course list-all`. Fixes #19 .