### PR TITLE
Add help command

### DIFF
--- a/src/commands/_utils.ts
+++ b/src/commands/_utils.ts
@@ -1,3 +1,5 @@
+import Command from '../Command';
+import CommandOptionChoice from '../CommandOptionChoice';
 import * as Discord from '../Discord';
 
 export const guildRoleListToMap = (
@@ -47,3 +49,17 @@ const getOptionsOfType = (options: any[], type: number) => {
 export const countSubCommands = (options: any[]): number => {
   return getOptionsOfType(options, 1).length;
 };
+
+export const getCommandOptionChoices = (
+  commandsList: Object
+): CommandOptionChoice[] => {
+  const choices: CommandOptionChoice[] = [];
+  for (const cmd of Object.values(commandsList)) {
+    const command = cmd.serialize();
+    choices.push(new CommandOptionChoice({
+      name: command.name, 
+      value: command.name
+    }));
+  }
+  return choices;
+}

--- a/src/commands/_utils.ts
+++ b/src/commands/_utils.ts
@@ -31,22 +31,19 @@ export const getHighestRank = (roles: Discord.Role[]): number => {
   return highest;
 };
 
-const getOptionsOfType = (
-  options: any[],
-  type: number,
-) => {
+const getOptionsOfType = (options: any[], type: number) => {
   const commandOptions: any[] = [];
-  if (!options) {return commandOptions; }
+  if (!options) {
+    return commandOptions;
+  }
   for (const option of options) {
     if (option.type == type) {
       commandOptions.push(option);
     }
   }
   return commandOptions;
-}
+};
 
-export const countSubCommands = (
-  options: any[],
-): number => {
+export const countSubCommands = (options: any[]): number => {
   return getOptionsOfType(options, 1).length;
-}
+};

--- a/src/commands/_utils.ts
+++ b/src/commands/_utils.ts
@@ -30,3 +30,23 @@ export const getHighestRank = (roles: Discord.Role[]): number => {
   }
   return highest;
 };
+
+const getOptionsOfType = (
+  options: any[],
+  type: number,
+) => {
+  const commandOptions: any[] = [];
+  if (!options) {return commandOptions; }
+  for (const option of options) {
+    if (option.type == type) {
+      commandOptions.push(option);
+    }
+  }
+  return commandOptions;
+}
+
+export const countSubCommands = (
+  options: any[],
+): number => {
+  return getOptionsOfType(options, 1).length;
+}

--- a/src/commands/_utils.ts
+++ b/src/commands/_utils.ts
@@ -33,8 +33,8 @@ export const getHighestRank = (roles: Discord.Role[]): number => {
   return highest;
 };
 
-const getOptionsOfType = (options: any[], type: number) => {
-  const commandOptions: any[] = [];
+const getOptionsOfType = (options: Discord.CommandOption[], type: number) => {
+  const commandOptions: Discord.CommandOption[] = [];
   if (!options) {
     return commandOptions;
   }
@@ -51,15 +51,17 @@ export const countSubCommands = (options: any[]): number => {
 };
 
 export const getCommandOptionChoices = (
-  commandsList: Object
+  commandsList: Record<string, Command>,
 ): CommandOptionChoice[] => {
   const choices: CommandOptionChoice[] = [];
   for (const cmd of Object.values(commandsList)) {
     const command = cmd.serialize();
-    choices.push(new CommandOptionChoice({
-      name: command.name, 
-      value: command.name
-    }));
+    choices.push(
+      new CommandOptionChoice({
+        name: command.name,
+        value: command.name,
+      }),
+    );
   }
   return choices;
-}
+};

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,0 +1,13 @@
+import ping from './ping';
+import poll from './poll';
+import mute from './mute';
+import course from './course';
+
+const commandsList = {
+  'ping': ping,
+  'mute': mute,
+  'poll': poll,
+  'course': course,
+};
+
+export default commandsList;

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -4,10 +4,10 @@ import mute from './mute';
 import course from './course';
 
 const commandsList = {
-  'ping': ping,
-  'mute': mute,
-  'poll': poll,
-  'course': course,
+  ping: ping,
+  mute: mute,
+  poll: poll,
+  course: course,
 };
 
 export default commandsList;

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -4,10 +4,10 @@ import mute from './mute';
 import course from './course';
 
 const commandsList = {
-  ping: ping,
-  mute: mute,
-  poll: poll,
-  course: course,
+  ping,
+  mute,
+  poll,
+  course,
 };
 
 export default commandsList;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -20,19 +20,22 @@ const help = new Command({
   ],
   handler: async ctx => {
     const chosenCommand = ctx.getArgument<string>('command')?.trim() as string;
+
     if (chosenCommand) {
-      const sections = [];
-      let description = '';
+      const sections: { name: string; description: string }[] = [];
+
+      let heading = '';
       // Find the command with the chosen name. find() will always return the correct command because options are fixed
       // so the secondary clause just ensures that cmd will always be defined (even though it isn't really needed)
       const cmd =
         commandsList.find(element => element.name == chosenCommand) ||
         commandsList[0];
+
       const command = cmd.serialize();
       if (command.options) {
         if (command.options[0].type == 1) {
           // subCommands are type 1
-          description = `\n\nSubcommands for /${command.name}:`;
+          heading = '\n\nSubcommands:';
           for (const subCommand of command.options) {
             sections.push({
               name: `/${command.name} ` + subCommand.name,
@@ -41,11 +44,11 @@ const help = new Command({
           }
         } else {
           // If options are not type 1, they are parameters (type 3)
-          description = `\n\nCommand parameters for /${command.name}:`;
+          heading = '\n\nCommand parameters:';
           for (const option of command.options) {
             let optional = '';
             if (!option.required) {
-              optional = ' (Optional)';
+              optional = ' (optional)';
             }
             sections.push({
               name: option.name + optional,
@@ -63,10 +66,8 @@ const help = new Command({
 
       await ctx.respondSilentlyWithEmbed({
         type: Discord.EmbedType.RICH,
-        title: `Usage information for /${command.name}`,
-        description: bold(
-          `/${command.name}: ${command.description}` + description,
-        ),
+        title: `Usage information for ${bold('/' + command.name)}`,
+        description: command.description + (heading && bold(heading)),
         fields,
       });
       return;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,18 +1,17 @@
 import * as Discord from '../Discord';
 import Command from '../Command';
 import CommandOption from '../CommandOption';
-import { bold } from '../format';
+import { bold, pluralize } from '../format';
 import { countSubCommands, getCommandOptionChoices } from './_utils';
 import commandsList from './commands';
 
 const help = new Command({
   name: 'help',
-  description: "Displays usage information for the bot's available commands",
+  description: "Displays usage information about HooskBot's available commands",
   options: [
     new CommandOption({
       name: 'command',
-      description:
-        'Optional command name for specific information about that command',
+      description: 'Get information about a specific command',
       required: false,
       choices: getCommandOptionChoices(commandsList),
       type: Discord.CommandOptionType.STRING,
@@ -72,16 +71,29 @@ const help = new Command({
       });
       return;
     } else {
-      const commands = [];
-      for (const cmd of commandsList) {
+      const commands: {
+        name: string;
+        description: string;
+        subCommands: string;
+      }[] = [];
+
+      // Sort the commands in alphabetical order of name.
+      const sortedCmdList = [...commandsList].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      );
+
+      for (const cmd of sortedCmdList) {
         const command = cmd.serialize();
         let subCommands = '';
         const subCommandCount = countSubCommands(command.options);
+
         if (subCommandCount > 0) {
-          subCommands = ` (${subCommandCount} subcommand${
-            subCommandCount > 1 ? 's' : ''
-          })`;
+          subCommands = ` (${subCommandCount} ${pluralize(
+            'subcommand',
+            subCommandCount,
+          )})`;
         }
+
         commands.push({
           name: command.name,
           description: command.description,
@@ -99,7 +111,7 @@ const help = new Command({
         type: Discord.EmbedType.RICH,
         title: 'Command List',
         description:
-          'Use `/help [command]` to view more information about a specific command',
+          'Run `/help [command]` to view more information about a specific command.',
         fields,
       });
     }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,95 @@
+import * as Discord from '../Discord';
+import Command from '../Command';
+import CommandOption from '../CommandOption';
+import commands from './index';
+import { countSubCommands } from './_utils';
+import { bold } from '../format';
+
+const help = new Command({
+  name: 'help',
+  description: 'Displays usage information for the bot\'s available commands',
+  options: [
+    new CommandOption({
+      name: 'command',
+      description: 'Optional command name for specific information about that command',
+      required: false,
+      type: Discord.CommandOptionType.STRING,
+    }),
+  ],
+  handler: async ctx => {
+    const chosenCommand = ctx.getArgument<string>('command')?.trim() as string;
+    
+    if (chosenCommand) {
+        const sections = [];
+        let description = '';
+        for (const cmd of Object.values(commands)) {
+            const command = cmd.serialize();
+            if (command.name == chosenCommand) {
+                if (command.options) {
+                    if (command.options[0].type == 1) { // subCommands are type 1
+                        description = `\n\nSubcommands for /${command.name}:`;
+                        for (const subCommand of command.options) {
+                            sections.push({
+                                name: `/${command.name} `+subCommand.name,
+                                description: subCommand.description
+                            });
+                        }
+                    } else { // If options are not type 1, they are parameters (type 3)
+                        description = `\n\nCommand parameters for /${command.name}:`;
+                        for (const option of command.options) {
+                            let optional = '';
+                            if (!option.required) { optional = ' (Optional)'; }
+                            sections.push({
+                                name: option.name + optional,
+                                description: option.description
+                            })
+                        }
+                    }
+                }
+
+                // Map section groups to Discord embed fields
+                const fields: Discord.EmbedField[] = sections.map(sec => ({
+                    name: sec.name, // The section name
+                    value: sec.description, // The section description
+                }));
+
+                await ctx.respondSilentlyWithEmbed({
+                    type: Discord.EmbedType.RICH,
+                    title: `Usage information for /${command.name}`,
+                    description: bold(`/${command.name}: ${command.description}` + description),
+                    fields,
+                });
+                return;
+            }
+        }
+        return await ctx.respondWithError(`${bold(chosenCommand)} is not a command, so help cannot be displayed.`);
+    }
+    else {
+        const commandsList = [];
+        for (const cmd of Object.values(commands)) {
+            const command = cmd.serialize();
+            let subCommands = '';
+            const subCommandCount = countSubCommands(command.options);
+            if (subCommandCount > 0) {
+                subCommands = ` (${subCommandCount} subcommand${(subCommandCount > 1) ? 's' : ''})`;
+            }   
+            commandsList.push({name: command.name, description: command.description, subCommands: subCommands});
+        }
+
+        // Map commands to Discord embed fields
+        const fields: Discord.EmbedField[] = commandsList.map(cmd => ({
+            name: '/'+cmd.name, // The command name
+            value: cmd.description + cmd.subCommands, // The command description
+        }));
+
+        return await ctx.respondSilentlyWithEmbed({
+            type: Discord.EmbedType.RICH,
+            title: 'Command List',
+            description: 'Use `/help [command]` to view more information about a specific command',
+            fields,
+        });
+    }
+  },
+});
+
+export default help;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -65,7 +65,6 @@ const help = new Command({
         fields,
       });
       return;
-        
     } else {
       const commands = [];
       for (const cmd of Object.values(commandsList)) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,15 +1,8 @@
-import ping from './ping';
-import poll from './poll';
-import mute from './mute';
-import course from './course';
+import commandsList from './commands';
 import help from './help';
 
-const commands = {
-  ping,
-  mute,
-  poll,
-  course,
-  help,
-};
+const commands = {'help': help}; // Add help command
+
+Object.assign(commands, commandsList); // Add remaining commands
 
 export default commands;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,7 +1,7 @@
 import commandsList from './commands';
 import help from './help';
 
-const commands = { help: help }; // Add help command
+const commands = { help }; // Add help command
 
 Object.assign(commands, commandsList); // Add remaining commands
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,7 +1,7 @@
 import commandsList from './commands';
 import help from './help';
 
-const commands = {'help': help}; // Add help command
+const commands = { help: help }; // Add help command
 
 Object.assign(commands, commandsList); // Add remaining commands
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,12 +2,14 @@ import ping from './ping';
 import poll from './poll';
 import mute from './mute';
 import course from './course';
+import help from './help';
 
 const commands = {
   ping,
   mute,
   poll,
   course,
+  help,
 };
 
 export default commands;

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,4 +1,15 @@
 /**
+ * Returns a plural version (with an appended `s`) of the provided word if the
+ * `count` isn't equal to 1.
+ *
+ * @param word The singular word.
+ * @param count The count of the word.
+ */
+export const pluralize = (word: string, count: number): string => {
+  return count === 1 ? word : word + 's';
+};
+
+/**
  * Bolds the supplied text using Discord's syntax.
  *
  * @param text The text to bold.


### PR DESCRIPTION
Adds a general help command for listing available commands, and also a separate help selection for individual commands.

I think it would be useful to allow the command option input to work with subcommands, allowing inputs like `course` and `course create` to both work (right now it only allows top level commands). A lot of the subcommands with options, some of which might be confusing, end up being hidden if only one level of command help is set up.