### PR TITLE
Only show commands with permission to run in help

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error",
     "@typescript-eslint/ban-ts-comment": "off",
-    "import/order": "error"
+    "import/order": "error",
+    "eqeqeq": "error"
   }
 }

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -388,7 +388,7 @@ class Api {
     emojiString: string,
     userId?: number,
   ): Promise<void> {
-    const target = userId == null ? '@me' : userId.toString();
+    const target = !userId ? '@me' : userId.toString();
     await performRequest(() =>
       this._http.delete(
         `/channels/${channelId}/messages/${messageId}/reactions/${prepareEmoji(
@@ -413,7 +413,7 @@ class Api {
     await performRequest(() =>
       this._http.delete(
         `/channels/${channelId}/messages/${messageId}/reactions${
-          emojiString == null ? '' : `/${prepareEmoji(emojiString)}`
+          !emojiString ? '' : `/${prepareEmoji(emojiString)}`
         }`,
       ),
     );

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -48,7 +48,7 @@ class Client {
   private _lastSeqNum: number | null;
   private _sessionId?: string;
 
-  // The axios client to pass to the ExecutionContext
+  // The axios client to pass to the execution context
   private readonly _http: AxiosInstance;
 
   // A callback function to be called when the connection is established.

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -19,9 +19,9 @@ type CommandProps = {
 class Command extends SubCommandGroup {
   readonly displayName: string;
   readonly followUpHandlers: Record<string, FollowUpHandler>;
-  private readonly _handler?: CommandHandler;
-  private readonly _requiredPerms: Discord.Permission[];
-  private readonly _defaultPerm: boolean;
+  readonly requiredPerms: Discord.Permission[];
+  readonly defaultPerm: boolean;
+  readonly handler?: CommandHandler;
 
   constructor(props: CommandProps) {
     const {
@@ -35,9 +35,9 @@ class Command extends SubCommandGroup {
     super(base);
     this.displayName = displayName;
     this.followUpHandlers = followUpHandlers ?? {};
-    this._handler = handler;
-    this._defaultPerm = default_permission ?? true;
-    this._requiredPerms = requiredPermissions ?? [];
+    this.handler = handler;
+    this.defaultPerm = default_permission ?? true;
+    this.requiredPerms = requiredPermissions ?? [];
   }
 
   /**
@@ -51,16 +51,16 @@ class Command extends SubCommandGroup {
       !(await SubCommand.checkPermissions(
         ctx,
         this.displayName,
-        this._requiredPerms,
+        this.requiredPerms,
       ))
     ) {
       return;
     }
 
-    if (this._handler) {
+    if (this.handler) {
       // Supply this command's follow-up handlers.
       ctx._setFollowUpHandlers(this.followUpHandlers);
-      return this._handler(ctx);
+      return this.handler(ctx);
     }
 
     ctx._advanceCommand();
@@ -76,8 +76,7 @@ class Command extends SubCommandGroup {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { type, ...serialized } = super.serialize();
     return {
-      default_permission: this._defaultPerm,
-      requiredPerms: this._requiredPerms,
+      default_permission: this.defaultPerm,
       ...serialized,
     };
   }

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -77,6 +77,7 @@ class Command extends SubCommandGroup {
     const { type, ...serialized } = super.serialize();
     return {
       default_permission: this._defaultPerm,
+      requiredPerms: this._requiredPerms,
       ...serialized,
     };
   }

--- a/src/CommandOption.ts
+++ b/src/CommandOption.ts
@@ -16,11 +16,11 @@ export type CommandOptionProps = {
  */
 class CommandOption {
   readonly name: string;
-  private readonly _opts: CommandOptionProps;
+  readonly props: CommandOptionProps;
 
   constructor(opts: CommandOptionProps) {
     this.name = opts.name;
-    this._opts = opts;
+    this.props = opts;
   }
 
   /**
@@ -29,9 +29,9 @@ class CommandOption {
    */
   serialize(): any {
     return {
-      ...this._opts,
-      choices: this._opts.choices?.map(c => c.serialize()),
-      options: this._opts.options?.map(c => c.serialize()),
+      ...this.props,
+      choices: this.props.choices?.map(c => c.serialize()),
+      options: this.props.options?.map(c => c.serialize()),
     };
   }
 }

--- a/src/SubCommand.ts
+++ b/src/SubCommand.ts
@@ -2,8 +2,8 @@ import * as Discord from './Discord';
 import SubCommandGroup, { SubCommandGroupProps } from './SubCommandGroup';
 import ExecutionContext from './ExecutionContext';
 import TriggerContext from './TriggerContext';
-import { hasPermission } from './permissions';
 import { bold } from './format';
+import { checkCtxPermissions } from './commands/_utils';
 
 export type CommandHandler = (
   ctx: ExecutionContext,
@@ -33,8 +33,8 @@ export type SubCommandOptions = {
 class SubCommand extends SubCommandGroup {
   readonly displayName: string;
   readonly followUpHandlers: Record<string, FollowUpHandler>;
-  private readonly _handler: CommandHandler;
-  private readonly _requiredPerms: Discord.Permission[];
+  readonly requiredPerms: Discord.Permission[];
+  readonly handler: CommandHandler;
 
   constructor(opts: SubCommandOptions) {
     const {
@@ -47,8 +47,8 @@ class SubCommand extends SubCommandGroup {
     super(base);
     this.displayName = displayName;
     this.followUpHandlers = followUpHandlers ?? {};
-    this._handler = handler;
-    this._requiredPerms = requiredPermissions ?? [];
+    this.handler = handler;
+    this.requiredPerms = requiredPermissions ?? [];
   }
 
   /**
@@ -62,7 +62,7 @@ class SubCommand extends SubCommandGroup {
       !(await SubCommand.checkPermissions(
         ctx,
         this.displayName,
-        this._requiredPerms,
+        this.requiredPerms,
       ))
     ) {
       return;
@@ -71,14 +71,14 @@ class SubCommand extends SubCommandGroup {
     // Supply this subcommand's follow-up handlers.
     ctx._setFollowUpHandlers(this.followUpHandlers);
 
-    return this._handler(ctx);
+    return this.handler(ctx);
   }
 
   /**
    * Checks whether the command execution is permitted according to the specified
    * required permissions.
    *
-   * @param ctx The ExecutionContext of the command.
+   * @param ctx The execution context of the command.
    * @param displayName The display name of the command.
    * @param requiredPerms The Discord permissions required to execute the command.
    */
@@ -87,25 +87,18 @@ class SubCommand extends SubCommandGroup {
     displayName: string,
     requiredPerms: Discord.Permission[],
   ): Promise<boolean> {
-    const { interaction } = ctx;
-    if (!interaction.member) {
-      throw new Error('No member found in interaction');
+    const [missingPerm, ok] = checkCtxPermissions(ctx, requiredPerms);
+
+    if (!ok) {
+      await ctx.respondWithError(
+        `The ${bold(displayName)} command requires the ` +
+          `${bold(
+            Discord.PermissionName[missingPerm as Discord.Permission],
+          )} permission, but you don't have it.`,
+      );
     }
 
-    const executorPerms = parseInt(interaction.member.permissions ?? '0');
-    for (const p of requiredPerms) {
-      if (!hasPermission(executorPerms, p)) {
-        await ctx.respondWithError(
-          `The ${bold(displayName)} command requires the ` +
-            `${bold(
-              Discord.PermissionName[p],
-            )} permission, but you don't have it.`,
-        );
-        return false;
-      }
-    }
-
-    return true;
+    return ok;
   }
 
   /**
@@ -114,7 +107,6 @@ class SubCommand extends SubCommandGroup {
    */
   serialize(): any {
     return {
-      requiredPerms: this._requiredPerms,
       ...super.serialize(),
       type: Discord.CommandOptionType.SUB_COMMAND,
     };

--- a/src/SubCommand.ts
+++ b/src/SubCommand.ts
@@ -114,6 +114,7 @@ class SubCommand extends SubCommandGroup {
    */
   serialize(): any {
     return {
+      requiredPerms: this._requiredPerms,
       ...super.serialize(),
       type: Discord.CommandOptionType.SUB_COMMAND,
     };

--- a/src/SubCommandGroup.ts
+++ b/src/SubCommandGroup.ts
@@ -17,12 +17,12 @@ export type SubCommandGroupProps = Omit<
  * also be `SubCommandGroup`s.
  */
 class SubCommandGroup extends CommandOption {
-  private readonly _subCommands: Record<string, SubCommand | SubCommandGroup>;
+  readonly subCommands: Record<string, SubCommand | SubCommandGroup>;
 
   constructor(props: SubCommandGroupProps) {
     super({ ...props, type: Discord.CommandOptionType.SUB_COMMAND_GROUP });
 
-    this._subCommands = {};
+    this.subCommands = {};
 
     if (props.options) {
       for (const opt of props.options) {
@@ -31,14 +31,14 @@ class SubCommandGroup extends CommandOption {
           const name = opt.name;
 
           // Ensure there isn't already a sub-command group with the same name.
-          if (name in this._subCommands) {
+          if (name in this.subCommands) {
             throw new Error(
               `Two or more sub-commands have the same name: ${name}`,
             );
           }
 
           // Place sub-commands into bins with the command name as the key.
-          this._subCommands[name] = opt;
+          this.subCommands[name] = opt;
         }
       }
     }
@@ -53,7 +53,7 @@ class SubCommandGroup extends CommandOption {
   execute(ctx: ExecutionContext): unknown | Promise<unknown> {
     const cmd = ctx._getCurrentCommand();
 
-    const subCommand = this._subCommands[cmd];
+    const subCommand = this.subCommands[cmd];
     if (subCommand) {
       // Mark the current command group as handled, and execute the sub-command.
       ctx._advanceCommand();

--- a/src/commands/_utils.ts
+++ b/src/commands/_utils.ts
@@ -1,4 +1,6 @@
 import Command from '../Command';
+import ExecutionContext from '../ExecutionContext';
+import { hasPermission } from '../permissions';
 import CommandOptionChoice from '../CommandOptionChoice';
 import * as Discord from '../Discord';
 
@@ -64,3 +66,24 @@ export const getCommandOptionChoices = (
   }
   return choices;
 };
+
+export const hasPermissions = (
+  ctx: ExecutionContext,
+  requiredPerms: Discord.Permission[],
+): boolean => {
+  const { interaction } = ctx;
+  if (!interaction.member) {
+    throw new Error('No member found in interaction');
+  }
+
+  if (!requiredPerms) {return true; }
+
+  const executorPerms = parseInt(interaction.member.permissions ?? '0');
+  for (const p of requiredPerms) {
+    if (!hasPermission(executorPerms, p)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/commands/_utils.ts
+++ b/src/commands/_utils.ts
@@ -3,6 +3,7 @@ import ExecutionContext from '../ExecutionContext';
 import { hasPermission } from '../permissions';
 import CommandOptionChoice from '../CommandOptionChoice';
 import * as Discord from '../Discord';
+import SubCommand from '../SubCommand';
 
 export const guildRoleListToMap = (
   roles: Discord.Role[],
@@ -25,6 +26,12 @@ export const compareRank = (
   return m1Rank - m2Rank;
 };
 
+/**
+ * Returns the highest rank number out of all the provided roles. Higher ranks
+ * mean higher precedence.
+ *
+ * @param roles An array of Discord roles to check.
+ */
 export const getHighestRank = (roles: Discord.Role[]): number => {
   let highest = 0;
   for (const r of roles) {
@@ -35,52 +42,55 @@ export const getHighestRank = (roles: Discord.Role[]): number => {
   return highest;
 };
 
-const getOptionsOfType = (
-  options: Discord.CommandOption[],
-  type: number,
-): Discord.CommandOption[] => {
-  const commandOptions: Discord.CommandOption[] = [];
-  if (!options) {
-    return commandOptions;
-  }
-  for (const option of options) {
-    if (option.type == type) {
-      commandOptions.push(option);
-    }
-  }
-  return commandOptions;
-};
-
-export const countSubCommands = (
+/**
+ * Counts the number of subcommands, out of the array of command options,
+ * that the executor of the execution context can access.
+ *
+ * @param ctx The execution context.
+ * @param cmd The command.
+ */
+export const countCtxAccessibleSubCommands = (
   ctx: ExecutionContext,
-  options: Discord.CommandOption[],
+  cmd: Command,
 ): number => {
-  const subCommands = getOptionsOfType(options, 1) as any;
-
   const validSubCommands =
-    subCommands.filter((subCommand: any) =>
-      hasPermissions(ctx, subCommand.requiredPerms),
-    ) || [];
+    Object.values(cmd.subCommands).filter(subCommand => {
+      if (!(subCommand instanceof SubCommand)) return false;
+      return checkCtxPermissions(ctx, subCommand.requiredPerms)[1];
+    }) || [];
   return validSubCommands.length;
 };
 
-const countAllSubCommands = (options: any[]): number => {
-  const subCommands = getOptionsOfType(options, 1);
-  return subCommands.length;
-};
-
-export const canRunCommand = (ctx: ExecutionContext, cmd: Command): boolean => {
-  const command = cmd.serialize();
-  // Permission to run command and either has more than one subcommand with permission to run or always has no subcommmands
-  // Filters out commands with only subcommands requring more permissions than the user has
+/**
+ * Returns whether the executor of the provided execution context can run the
+ * provided command.
+ *
+ * @param ctx The execution context.
+ * @param cmd The command being run.
+ */
+export const ctxCanRunCommand = (
+  ctx: ExecutionContext,
+  cmd: Command,
+): boolean => {
   return (
-    hasPermissions(ctx, command.requiredPerms) &&
-    (countSubCommands(ctx, command.options) != 0 ||
-      countAllSubCommands(command.options) == 0)
+    // Ensure the executor possesses the required permissions.
+    checkCtxPermissions(ctx, cmd.requiredPerms)[1] &&
+    // Ensure the executor can access at least 1 subcommand;
+    (countCtxAccessibleSubCommands(ctx, cmd) !== 0 ||
+      // OR there are no subcommands.
+      Object.values(cmd.subCommands).length === 0)
   );
 };
 
-export const getCommandOptionChoices = (
+/**
+ * Converts a list of commands into a list of command option choices.
+ *
+ * This is used by the `/help` command to auto-complete the names of commands
+ * with help texts.
+ *
+ * @param commandsList A list of commands.
+ */
+export const convertCommandListToOptionsList = (
   commandsList: Command[],
 ): CommandOptionChoice[] => {
   const choices: CommandOptionChoice[] = [];
@@ -95,25 +105,34 @@ export const getCommandOptionChoices = (
   return choices;
 };
 
-export const hasPermissions = (
+/**
+ * Checks whether the executor of the provided execution context has all of the
+ * provided required permissions.
+ *
+ * Returns a 2-element array:
+ *  - 0: The missing Discord permission, or undefined.
+ *  - 1: Whether all permission were met.
+ *
+ * @param ctx The execution context.
+ * @param requiredPerms The required permissions.
+ */
+export const checkCtxPermissions = (
   ctx: ExecutionContext,
   requiredPerms: Discord.Permission[],
-): boolean => {
+): [Discord.Permission, false] | [undefined, true] => {
   const { interaction } = ctx;
   if (!interaction.member) {
     throw new Error('No member found in interaction');
   }
 
-  if (!requiredPerms) {
-    return true;
-  }
-
   const executorPerms = parseInt(interaction.member.permissions ?? '0');
-  for (const p of requiredPerms) {
-    if (!hasPermission(executorPerms, p)) {
-      return false;
+
+  // Ensure that every required permission is possessed by the executor.
+  for (const req of requiredPerms) {
+    if (!hasPermission(executorPerms, req)) {
+      return [req, false];
     }
   }
 
-  return true;
+  return [undefined, true];
 };

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -7,6 +7,6 @@ import pfp from './pfp';
 import bot from './bot';
 import say from './say';
 
-const commandsList: Command[] = [ping, mute, poll, course, pfp, bot, say];
+const commandList: Command[] = [ping, mute, poll, course, pfp, bot, say];
 
-export default commandsList;
+export default commandList;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,13 +2,14 @@ import * as Discord from '../Discord';
 import Command from '../Command';
 import CommandOption from '../CommandOption';
 import { bold, pluralize } from '../format';
+import SubCommand from '../SubCommand';
 import {
-  canRunCommand,
-  countSubCommands,
-  getCommandOptionChoices,
-  hasPermissions,
+  ctxCanRunCommand,
+  countCtxAccessibleSubCommands,
+  convertCommandListToOptionsList,
+  checkCtxPermissions,
 } from './_utils';
-import commandsList from './commands';
+import commandList from './commands';
 
 const help = new Command({
   name: 'help',
@@ -19,49 +20,49 @@ const help = new Command({
       name: 'command',
       description: 'Get information about a specific command',
       required: false,
-      choices: getCommandOptionChoices(commandsList),
+      choices: convertCommandListToOptionsList(commandList),
       type: Discord.CommandOptionType.STRING,
     }),
   ],
   handler: async ctx => {
-    const chosenCommand = ctx.getArgument<string>('command')?.trim() as string;
+    const chosenCommand = ctx.getArgument<string>('command')?.trim();
 
     if (chosenCommand) {
       const sections: { name: string; description: string }[] = [];
 
       let heading = '';
-      // Find the command with the chosen name. find() will always return the correct command because options are fixed
-      // so the secondary clause just ensures that cmd will always be defined (even though it isn't really needed)
-      const cmd =
-        commandsList.find(element => element.name == chosenCommand) ||
-        commandsList[0];
 
-      const command = cmd.serialize();
-      if (command.options) {
-        if (command.options[0].type == 1) {
-          // subCommands are type 1
-          heading = '\n\nSubcommands:';
-          for (const subCommand of command.options) {
-            if (hasPermissions(ctx, subCommand.requiredPerms)) {
-              sections.push({
-                name: `/${command.name} ` + subCommand.name,
-                description: subCommand.description,
-              });
-            }
-          }
-        } else {
-          // If options are not type 1, they are parameters (type 3)
-          heading = '\n\nCommand parameters:';
-          for (const option of command.options) {
-            let optional = '';
-            if (!option.required) {
-              optional = ' (optional)';
-            }
+      // Find the command with the given name.
+      const command =
+        commandList.find(element => element.name === chosenCommand) ??
+        commandList[0];
+
+      const subCommands = Object.values(command.subCommands);
+      if (subCommands.length > 0 && subCommands[0] instanceof SubCommand) {
+        heading = '\n\nSubcommands:';
+        for (const sub of subCommands) {
+          // Make sure we only count subcommands.
+          if (!(sub instanceof SubCommand)) continue;
+          if (checkCtxPermissions(ctx, sub.requiredPerms)[1]) {
             sections.push({
-              name: option.name + optional,
-              description: option.description,
+              name: `/${command.name} ` + sub.name,
+              description: sub.props.description,
             });
           }
+        }
+      } else if ((command.props.options ?? []).length > 0) {
+        // If the command has no subcommands but it has parameters, then list
+        // the parameters.
+        heading = '\n\nCommand parameters:';
+        for (const option of command.props.options ?? []) {
+          let name = option.name;
+          if (!option.props.required) {
+            name += ' (optional)';
+          }
+          sections.push({
+            name: name,
+            description: option.props.description,
+          });
         }
       }
 
@@ -71,59 +72,59 @@ const help = new Command({
         value: sec.description, // The section description
       }));
 
-      await ctx.respondSilentlyWithEmbed({
+      return ctx.respondSilentlyWithEmbed({
         type: Discord.EmbedType.RICH,
         title: `Usage information for ${bold('/' + command.name)}`,
-        description: command.description + (heading && bold(heading)),
-        fields,
-      });
-      return;
-    } else {
-      const commands: {
-        name: string;
-        description: string;
-        subCommands: string;
-      }[] = [];
-
-      // Sort the commands in alphabetical order of name.
-      const sortedCmdList = [...commandsList].sort((a, b) =>
-        a.name.localeCompare(b.name),
-      );
-
-      for (const cmd of sortedCmdList) {
-        if (canRunCommand(ctx, cmd)) {
-          const command = cmd.serialize();
-          let subCommands = '';
-          const subCommandCount = countSubCommands(ctx, command.options);
-          if (subCommandCount > 0) {
-            subCommands = ` (${subCommandCount} ${pluralize(
-              'subcommand',
-              subCommandCount,
-            )})`;
-          }
-
-          commands.push({
-            name: command.name,
-            description: command.description,
-            subCommands: subCommands,
-          });
-        }
-      }
-
-      // Map commands to Discord embed fields
-      const fields: Discord.EmbedField[] = commands.map(cmd => ({
-        name: '/' + cmd.name, // The command name
-        value: cmd.description + cmd.subCommands, // The command description
-      }));
-
-      return await ctx.respondSilentlyWithEmbed({
-        type: Discord.EmbedType.RICH,
-        title: 'Command List',
-        description:
-          'Run `/help [command]` to view more information about a specific command.',
+        description: command.props.description + (heading && bold(heading)),
         fields,
       });
     }
+
+    // No specific command was chosen, so output entire command list.
+    const displayedCmds: {
+      name: string;
+      description: string;
+      subCommands: string;
+    }[] = [];
+
+    // Sort the commands in alphabetical order of name. The spread operator makes
+    // a shallow copy of the command list.
+    const sortedCmdList = [...commandList].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+
+    for (const cmd of sortedCmdList) {
+      if (ctxCanRunCommand(ctx, cmd)) {
+        let subCommands = '';
+        const subCommandCount = countCtxAccessibleSubCommands(ctx, cmd);
+        if (subCommandCount > 0) {
+          subCommands = ` (${subCommandCount} ${pluralize(
+            'subcommand',
+            subCommandCount,
+          )})`;
+        }
+
+        displayedCmds.push({
+          name: cmd.name,
+          description: cmd.props.description,
+          subCommands: subCommands,
+        });
+      }
+    }
+
+    // Map commands to Discord embed fields
+    const fields: Discord.EmbedField[] = displayedCmds.map(cmd => ({
+      name: '/' + cmd.name, // The command name
+      value: cmd.description + cmd.subCommands, // The command description
+    }));
+
+    return await ctx.respondSilentlyWithEmbed({
+      type: Discord.EmbedType.RICH,
+      title: 'Command List',
+      description:
+        'Run `/help [command]` to view more information about a specific command.',
+      fields,
+    });
   },
 });
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,7 +2,12 @@ import * as Discord from '../Discord';
 import Command from '../Command';
 import CommandOption from '../CommandOption';
 import { bold, pluralize } from '../format';
-import { countSubCommands, getCommandOptionChoices, hasPermissions } from './_utils';
+import {
+  canRunCommand,
+  countSubCommands,
+  getCommandOptionChoices,
+  hasPermissions,
+} from './_utils';
 import commandsList from './commands';
 
 const help = new Command({
@@ -86,12 +91,10 @@ const help = new Command({
       );
 
       for (const cmd of sortedCmdList) {
-        const command = cmd.serialize();
-        if (hasPermissions(ctx, command.requiredPerms)) {
-          console.log(command.name + `Requires ${command.requiredPerms}`);
+        if (canRunCommand(ctx, cmd)) {
+          const command = cmd.serialize();
           let subCommands = '';
-          const subCommandCount = countSubCommands(command.options);
-
+          const subCommandCount = countSubCommands(ctx, command.options);
           if (subCommandCount > 0) {
             subCommands = ` (${subCommandCount} ${pluralize(
               'subcommand',

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,11 +1,6 @@
-import commandsList from './commands';
+import commandList from './commands';
 import help from './help';
 
-const commands = [help]; // Add help command
-
-for (const command of commandsList) {
-  // Add remaining commands
-  commands.push(command);
-}
+const commands = [help, ...commandList]; // Add help command.
 
 export default commands;

--- a/src/commands/poll.ts
+++ b/src/commands/poll.ts
@@ -47,7 +47,7 @@ const poll = new Command({
           }
         }
 
-        if (customEmojis != null)
+        if (customEmojis !== null)
           customEmojis.forEach(element => {
             ctx.api.createReaction(msg.id, msg.channel_id, element);
           });


### PR DESCRIPTION
Adds new restrictions to the `help` command to only show commands/subcommands that the user can run. Also updates the subcommand count to reflect permissions.

Fixes #42.