### PR TITLE
Enhance countdown commands

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -231,7 +231,7 @@ class Api {
   }
 
   /**
-   * Deletes a new channel in a guild.
+   * Deletes a channel in a guild.
    *
    * @param channelId The ID of the channel.
    */

--- a/src/commands/birthday/subcommands/list.ts
+++ b/src/commands/birthday/subcommands/list.ts
@@ -55,9 +55,15 @@ const list = new SubCommand({
       value: sub.list, // The birthday list.
     }));
 
+    let embedDescription = '';
+    if (fields.length < 1) {
+      embedDescription = 'There are no stored birthdays.';
+    }
+
     await ctx.interactionApi.respondSilentlyWithEmbed({
       type: Discord.EmbedType.RICH,
       title: 'All Birthdays',
+      description: embedDescription,
       fields,
     });
   },

--- a/src/commands/birthday/subcommands/showSchedule.ts
+++ b/src/commands/birthday/subcommands/showSchedule.ts
@@ -7,8 +7,8 @@ import { formatHourMinute } from '../_common';
 
 const showSchedule = new SubCommand({
   name: 'show-schedule',
-  displayName: 'Get Schedule',
-  description: 'Get schedule for sending birthday messages',
+  displayName: 'Show Schedule',
+  description: 'Show schedule for sending birthday messages',
   requiredPermissions: [Discord.Permission.MANAGE_ROLES],
   handler: async ctx => {
     const guildId = ctx.mustGetGuildId();

--- a/src/commands/countdown/subcommands/create.ts
+++ b/src/commands/countdown/subcommands/create.ts
@@ -41,7 +41,27 @@ const create = new SubCommand({
       return respondWithInvalidDate(ctx);
     }
 
+    // Retrieve all current dates and events to generate this new event's ID
+    const dates = await (await ctx.countdowns().scan(guildId))
+      .sort({ _id: 1 })
+      .toArray();
+
+    let highestId = 0;
+    for (const d of dates) {
+      if (d.events.length === 0) continue;
+
+      for (const ev of d.events) {
+        if (ev.id > highestId) {
+          highestId = ev.id;
+        }
+      }
+    }
+
+    // Ensure all IDs are positive, natural numbers
+    const nextId = highestId >= 0 ? highestId + 1 : 1;
+
     await ctx.countdowns().create(guildId, date.format('YYYY-MM-DD'), {
+      id: nextId,
       name: eventName,
       channel: channel,
     });

--- a/src/commands/countdown/subcommands/index.ts
+++ b/src/commands/countdown/subcommands/index.ts
@@ -2,7 +2,8 @@ import create from './create';
 import del from './delete';
 import list from './list';
 import setSchedule from './setSchedule';
+import showSchedule from './showSchedule';
 
-const subCommands = [create, del, list, setSchedule];
+const subCommands = [create, del, list, setSchedule, showSchedule];
 
 export default subCommands;

--- a/src/commands/countdown/subcommands/list.ts
+++ b/src/commands/countdown/subcommands/list.ts
@@ -53,9 +53,15 @@ const list = new SubCommand({
       value: sub.list, // The countdown list.
     }));
 
+    let embedDescription = '';
+    if (fields.length < 1) {
+      embedDescription = 'There are no current countdowns.';
+    }
+
     await ctx.interactionApi.respondWithEmbed({
       type: Discord.EmbedType.RICH,
-      title: 'All Countdowns',
+      title: 'Countdowns',
+      description: embedDescription,
       fields,
     });
   },

--- a/src/commands/countdown/subcommands/list.ts
+++ b/src/commands/countdown/subcommands/list.ts
@@ -42,7 +42,9 @@ const list = new SubCommand({
       if (d.events.length > 0) {
         curGroup.list += `${bold(
           month + ' ' + dayjs(d._id).format('DD'),
-        )}: ${d.events.map(event => event.name).join(' • ')}\n`;
+        )}: ${d.events
+          .map(event => `${event.name} - \`ID ${event.id}\``)
+          .join(' • ')}\n`;
       }
     }
 

--- a/src/commands/countdown/subcommands/showSchedule.ts
+++ b/src/commands/countdown/subcommands/showSchedule.ts
@@ -1,35 +1,35 @@
 import * as Discord from '../../../Discord';
 import SubCommand from '../../../SubCommand';
 import { Config } from '../../../database';
-import { BirthdaysConfig } from '../../../repository';
+import { CountdownConfig } from '../../../repository/ConfigRepo';
 import { bold } from '../../../format';
-import { formatHourMinute } from '../_common';
+import { formatHourMinute } from '../../birthday/_common';
 
 const showSchedule = new SubCommand({
   name: 'show-schedule',
-  displayName: 'Get Schedule',
-  description: 'Get schedule for sending birthday messages',
+  displayName: 'Show Schedule',
+  description: 'Show schedule for sending countdown announcements',
   requiredPermissions: [Discord.Permission.MANAGE_ROLES],
   handler: async ctx => {
     const guildId = ctx.mustGetGuildId();
 
     // Fetch the role configuration from the database.
-    const birthdaysCfg = await ctx
+    const countdownCfg = await ctx
       .config()
-      .get<BirthdaysConfig>(guildId, Config.BIRTHDAYS);
+      .get<CountdownConfig>(guildId, Config.COUNTDOWNS);
     if (
-      !birthdaysCfg ||
-      birthdaysCfg.scheduledHour === undefined ||
-      birthdaysCfg.scheduledMinute === undefined
+      !countdownCfg ||
+      countdownCfg.scheduledHour === undefined ||
+      countdownCfg.scheduledMinute === undefined
     ) {
       return ctx.interactionApi.respondWithMessage(
-        `No birthday schedule set. Run \`/birthday set-schedule\`.`,
+        `No countdown schedule is set. Run \`/countdown set-schedule\`.`,
       );
     }
 
-    const { scheduledHour, scheduledMinute } = birthdaysCfg;
+    const { scheduledHour, scheduledMinute } = countdownCfg;
     return ctx.interactionApi.respondWithMessage(
-      `Birthday messages send every day at ` +
+      `Countdown announcements send every day at ` +
         bold(formatHourMinute(scheduledHour, scheduledMinute)),
     );
   },

--- a/src/commands/poll/subcommands/list.ts
+++ b/src/commands/poll/subcommands/list.ts
@@ -28,7 +28,7 @@ const list = new SubCommand({
       fields: embedFields,
     };
     if (embedFields.length < 1) {
-      embed.description = "You don't have any active polls";
+      embed.description = "You don't have any active polls.";
     }
 
     return ctx.interactionApi.respondWithEmbed(embed);

--- a/src/database/constants.ts
+++ b/src/database/constants.ts
@@ -8,6 +8,7 @@ export enum Collection {
   MAIL = 'mail',
   BIRTHDAYS = 'birthdays',
   COUNTDOWNS = 'countdowns',
+  COUNTDOWN_ANNOUNCEMENTS = 'countdownAnnouncements',
   JOBS = 'jobs',
 }
 
@@ -21,4 +22,5 @@ export enum Config {
   MAIL = 'mail',
   BIRTHDAYS = 'birthdays',
   COUNTDOWNS = 'countdowns',
+  COUNTDOWN_ANNOUNCEMENTS = 'countdownAnnouncements',
 }

--- a/src/jobHandlers/sendCountdownAnnoucements.ts
+++ b/src/jobHandlers/sendCountdownAnnoucements.ts
@@ -32,7 +32,7 @@ const sendCountdownAnnouncements: JobHandler<JobType.SEND_COUNTDOWN_ANNOUNCEMENT
       }
 
       for (const ev of date.events) {
-        await ctx.api.createMessage(ev.channel, {
+        const sentMessage = await ctx.api.createMessage(ev.channel, {
           embeds: [
             {
               title: `🗓️ Countdown to ${ev.name}`,
@@ -40,6 +40,24 @@ const sendCountdownAnnouncements: JobHandler<JobType.SEND_COUNTDOWN_ANNOUNCEMENT
             },
           ],
         });
+
+        const channelId = sentMessage.channel_id;
+        const messageId = sentMessage.id;
+        const eventId = ev.id;
+
+        if (daysToEnd === 0) {
+          await ctx.repos.countdownAnnouncements.deleteByEventId(
+            guildId,
+            eventId,
+          );
+        } else {
+          await ctx.repos.countdownAnnouncements.create(
+            guildId,
+            channelId,
+            messageId,
+            eventId,
+          );
+        }
       }
     }
   };

--- a/src/repository/CountdownAnnouncementRepo.ts
+++ b/src/repository/CountdownAnnouncementRepo.ts
@@ -1,0 +1,53 @@
+import { Collection as MongoCollection } from 'mongodb';
+import { Collection, Database } from '../database';
+
+export type CountdownAnnouncement = {
+  _id: string;
+  channelId: string;
+  eventId: number;
+};
+
+class CountdownAnnouncementRepo {
+  private readonly _db: Database;
+
+  constructor(db: Database) {
+    this._db = db;
+  }
+
+  async getByMessageId(
+    guildId: string,
+    messageId: string,
+  ): Promise<CountdownAnnouncement | null> {
+    return this.collection(guildId).findOne({ _id: messageId });
+  }
+
+  async create(
+    guildId: string,
+    messageId: string,
+    channelId: string,
+    eventId: number,
+  ): Promise<void> {
+    await this.collection(guildId).insertOne({
+      _id: messageId,
+      channelId,
+      eventId,
+    });
+  }
+
+  async deleteByEventId(guildId: string, eventId: number): Promise<void> {
+    await this.collection(guildId).deleteMany({ eventId });
+  }
+
+  /**
+   * Returns the `countdownAnnouncements` collection for the specified guild.
+   *
+   * @param guildId The ID of the guild.
+   */
+  collection(guildId: string): MongoCollection<CountdownAnnouncement> {
+    return this._db
+      .getDb(guildId)
+      .collection(Collection.COUNTDOWN_ANNOUNCEMENTS);
+  }
+}
+
+export default CountdownAnnouncementRepo;

--- a/src/repository/CountdownRepo.ts
+++ b/src/repository/CountdownRepo.ts
@@ -7,6 +7,7 @@ export type CountdownDate = {
 };
 
 export type Event = {
+  id: number;
   name: string;
   channel: string;
 };
@@ -16,6 +17,10 @@ class CountdownRepo {
 
   constructor(db: Database) {
     this._db = db;
+  }
+
+  async getById(guildId: string, id: number): Promise<CountdownDate | null> {
+    return this.collection(guildId).findOne({ 'events.id': id });
   }
 
   async getByDate(
@@ -45,14 +50,10 @@ class CountdownRepo {
     await this.collection(guildId).deleteOne({ _id: date });
   }
 
-  async deleteEvent(
-    guildId: string,
-    date: string,
-    eventName: string,
-  ): Promise<void> {
+  async deleteEvent(guildId: string, date: string, id: number): Promise<void> {
     await this.collection(guildId).updateOne(
       { _id: date },
-      { $pull: { events: { name: eventName } } },
+      { $pull: { events: { id } } },
     );
   }
 

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -5,6 +5,7 @@ import ConfigRepo from './ConfigRepo';
 import PollRepo from './PollRepo';
 import MailRepo from './MailRepo';
 import CountdownRepo from './CountdownRepo';
+import CountdownAnnouncementRepo from './CountdownAnnouncementRepo';
 import JobRepo from './JobRepo';
 
 export type { Birthday, BirthdayMessage } from './BirthdayRepo';
@@ -17,6 +18,7 @@ export type Repositories = {
   mail: MailRepo;
   config: ConfigRepo;
   countdowns: CountdownRepo;
+  countdownAnnouncements: CountdownAnnouncementRepo;
   poll: PollRepo;
 };
 
@@ -28,10 +30,9 @@ export const setupRepos = (db: Database): Repositories => {
     mail: new MailRepo(db),
     config: new ConfigRepo(db),
     countdowns: new CountdownRepo(db),
+    countdownAnnouncements: new CountdownAnnouncementRepo(db),
     poll: new PollRepo(db),
   };
 };
 
-export { RolesConfig } from './ConfigRepo';
-export { GuildConfig } from './ConfigRepo';
-export { BirthdaysConfig } from './ConfigRepo';
+export { BirthdaysConfig, GuildConfig, RolesConfig } from './ConfigRepo';


### PR DESCRIPTION
Main changes:

- `/countdown show-schedule` command added
- Each event is assigned a numerical ID
- Events are deleted with just their ID (get from `/countdown list`)
- Announcement message IDs are stored in the database
- Announcement messages are deleted once a countdown ends